### PR TITLE
left align pre tag text

### DIFF
--- a/silk/templates/silk/base/base.html
+++ b/silk/templates/silk/base/base.html
@@ -22,6 +22,7 @@
             padding: 0.5em !important;
             margin: 0 !important;
             font-size: 14px;
+            text-align: left;
         }
 
         code {


### PR DESCRIPTION
Profller output, in a `pre` tag, is centered, due to an inherited rule for `#query-div` in `summary.css`:

```
#query-div {
    margin: auto;
    width: 960px;
    text-align: center;
}
```
