### PR TITLE
gprof2dot had a breaking change in 2017.09.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ Pillow>=3.2
 django>=1.8
 freezegun>=0.3
 factory-boy>=2.8.1
-gprof2dot>=2016.10.13
+gprof2dot>=2016.10.13,<2017.09.19

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
         'Jinja2',
         'autopep8',
         'pytz',
-        'gprof2dot',
+        'gprof2dot<2017.09.19',
     ]
 )


### PR DESCRIPTION
gprof2dot introduced a breaking change in the latest version (specifically in [this commit](https://github.com/jrfonseca/gprof2dot/commit/45342280c636dffca74cbdc3e7ac1b4438f57c1c)). As a result the test suite for silk fails.

I've pinned the version to `<2017.09.19`.