### PR TITLE
Lint silk directory and fix a python 3 blocker

### DIFF
--- a/silk/collector.py
+++ b/silk/collector.py
@@ -78,17 +78,13 @@ class DataCollector(with_metaclass(Singleton, object)):
             self._raise_not_configured(
                 'Attempt to access %s without initialisation.' % typ
             )
-        if not typ in objects:
+        if typ not in objects:
             objects[typ] = {}
         return objects[typ]
 
     @property
     def profiles(self):
         return self._get_objects(TYP_PROFILES)
-
-    @property
-    def silk_queries(self):
-        return self._get_objects('silk_queries')
 
     def configure(self, request=None):
         silky_config = SilkyConfig()
@@ -119,7 +115,7 @@ class DataCollector(with_metaclass(Singleton, object)):
                 self._raise_not_configured(
                     'Attempt to register object of type %s without initialisation. '
                 )
-            if not typ in objects:
+            if typ not in objects:
                 self.objects[typ] = {}
             self.objects[typ][ident] = arg
 

--- a/silk/models.py
+++ b/silk/models.py
@@ -295,7 +295,7 @@ class BaseProfile(models.Model):
     request = ForeignKey(
         Request, null=True, blank=True, db_index=True,
         on_delete=models.CASCADE,
-       )
+    )
     time_taken = FloatField(blank=True, null=True)
 
     class Meta:

--- a/silk/profiling/dynamic.py
+++ b/silk/profiling/dynamic.py
@@ -53,7 +53,7 @@ def profile_function_or_method(module, func, name=None):
     @param module: module object or module name in form 'path.to.module'
     @param func: function object or function name in form 'foo' or 'Class.method'
     """
-    if type(module) is str or type(module) is unicode:
+    if isinstance(module, six.string_types) or isinstance(module, six.text_type):
         module = _get_module(module)
     decorator = silk_profile(name, _dynamic=True)
     func_name = func

--- a/silk/profiling/profiler.py
+++ b/silk/profiling/profiler.py
@@ -118,7 +118,6 @@ class silk_profile(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self._silk_installed() and self._should_profile():
             with silk_meta_profiler():
-                start_time = None
                 exception_raised = exc_type is not None
                 self.profile['exception_raised'] = exception_raised
                 self.profile['end_time'] = timezone.now()
@@ -177,7 +176,7 @@ class silk_profile(object):
             return target
 
     def distinct_queries(self):
-        queries = [x for x in self._queries_after if not x in self._queries_before]
+        queries = [x for x in self._queries_after if x not in self._queries_before]
         return queries
 
 

--- a/silk/request_filters.py
+++ b/silk/request_filters.py
@@ -213,7 +213,7 @@ def filters_from_request(request):
         if splt[0].startswith('filter'):
             ident = splt[1]
             typ = splt[2]
-            if not ident in raw_filters:
+            if ident not in raw_filters:
                 raw_filters[ident] = {}
             raw_filters[ident][typ] = request.POST[key]
     filters = {}

--- a/silk/templatetags/silk_filters.py
+++ b/silk/templatetags/silk_filters.py
@@ -9,12 +9,14 @@ from django.utils.safestring import mark_safe
 register = Library()
 
 
+def _no_op(x):
+    return x
+
+
 def _esc_func(autoescape):
     if autoescape:
-        esc = conditional_escape
-    else:
-        esc = lambda x: x
-    return esc
+        return conditional_escape
+    return _no_op
 
 
 @stringfilter
@@ -85,6 +87,7 @@ def body_filter(value):
         return 'Too big!'
     else:
         return value
+
 
 spacify.needs_autoescape = True
 filepath_urlify.needs_autoescape = True

--- a/silk/templatetags/silk_inclusion.py
+++ b/silk/templatetags/silk_inclusion.py
@@ -34,6 +34,7 @@ def heading(text):
 def code(lines, actual_line):
     return {'code': lines, 'actual_line': [x.strip() for x in actual_line]}
 
+
 register.inclusion_tag('silk/inclusion/request_summary.html')(request_summary)
 register.inclusion_tag('silk/inclusion/profile_summary.html')(profile_summary)
 register.inclusion_tag('silk/inclusion/code.html')(code)

--- a/silk/views/requests.py
+++ b/silk/views/requests.py
@@ -39,8 +39,8 @@ class RequestsView(View):
         },
         'db_time': {
             'label': 'Time on queries',
-            'additional_query_filter': lambda x: x.annotate(db_time=Sum('queries__time_taken')) \
-                .filter(db_time__gte=0)
+            'additional_query_filter': lambda x: x.annotate(db_time=Sum('queries__time_taken'))
+            .filter(db_time__gte=0)
         },
     }
     order_dir = {

--- a/silk/views/sql_detail.py
+++ b/silk/views/sql_detail.py
@@ -45,7 +45,7 @@ class SQLDetailView(View):
         line_num = int(request.GET.get('line_num', 0))
         tb = sql_query.traceback_ln_only
         str, files = self._urlify(tb)
-        if file_path and not file_path in files:
+        if file_path and file_path not in files:
             raise PermissionDenied
         tb = [mark_safe(x) for x in str.split('\n')]
         context = {

--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     # Django>=1.8
     from django.template.context_processors import csrf
-    
+
 from django.db.models import Avg, Count, Sum, Max
 from django.shortcuts import render
 from django.utils.decorators import method_decorator


### PR DESCRIPTION
Some minor linting to make silk PEP8 compatible (ignoring line length).  Also, replacing the `unicode` keyword with `six` because `unicode` was removed in python 3.