### PR TITLE
Fix missing db_time field

### DIFF
--- a/silk/views/summary.py
+++ b/silk/views/summary.py
@@ -39,7 +39,7 @@ class SummaryView(View):
         return requests
 
     def _time_spent_in_db_by_view(self, filters):
-        values_list = models.Request.objects.filter(*filters).values_list('view_name').annotate(t=Sum('queries__time_taken')).filter(db_time__gte=0).order_by('-t')[:5]
+        values_list = models.Request.objects.filter(*filters).values_list('view_name').annotate(t=Sum('queries__time_taken')).filter(t__gte=0).order_by('-t')[:5]
         requests = []
         for view, _ in values_list:
             r = models.Request.objects.filter(view_name=view, *filters).annotate(t=Sum('queries__time_taken')).order_by('-t')[0]


### PR DESCRIPTION
Not sure how this got past tests for the original pull request #225, but since the filter is on an annotation, the filter field must match the annotation field.  