### PR TITLE
Release 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jazzband/silk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)",
   "main": "index.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-silk',
-    version='1.0.0',
+    version='1.1.0',
     packages=['silk'],
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
Resolves #187, Resolves #229. 

Proposed release notes (feel free to modify):

```
 - Support for Django 2 and Python 3.6
 - Support garbage collecting old profiling data
 - Moved project to jazzband
 - Better data visualizations (#194)
 - Added ability to filter requests by http verb (#192)
 - Various UI fixes
 - Various bug and testing fixes
```

Commits since 1.0.0:
```
* ec11ac8 - (HEAD -> release, origin/release) Release 1.1.0 (2 minutes ago) <Albert Wang>
* abe6d84 - (origin/master, origin/HEAD, master) Switch to set method for modifying manytomany fields (24 hours ago) <Albert Wang>
* 26bbc67 - Add app_name to example app (2 weeks ago) <Albert Wang>
* aefa8a3 - Remove unneeded app_name from test project to be django 2 compatible (3 weeks ago) <Albert Wang>
* 236d2a3 - Convert tabs to spaces (3 weeks ago) <Albert Wang>
* 839fd85 - Add django 2 to tests (3 weeks ago) <Albert Wang>
* 9a71ec9 - Update package versions for test project (4 days ago) <Albert Wang>
* 21e31ee - Return immediately (13 days ago) <Dmitry Dygalo>
* 56e085f - Fix missing db_time field (#234) (2 weeks ago) <Albert Wang>
* 4633dbc - Fix python 3 incompatibility (3 weeks ago) <Albert Wang>
* cb41b2e - Fix non line-length pep8 issues in silk directory (3 weeks ago) <Albert Wang>
* f1ef5d1 - Filter out views that took no time in the database for the most time spend in database requests on the dashboard. (5 weeks ago) <Harro van der Klauw>
* 99b0cd0 - Fix flaky test by rounding off floats (3 weeks ago) <Albert Wang>
* 61e62fd - Moves distributions setting out of the on flag (3 weeks ago) <Andrew Velis>
* 8782b78 - Fix github silk links to point to jazzband (#230) (3 weeks ago) <Albert Wang>
* 48a2a6c - Fix Django 2 deprecations (#227) (3 weeks ago) <Albert Wang>
* 6e93cd4 - Update docs to clarify how to install the middleware (#228) (4 weeks ago) <Albert Wang>
* 09cf2c6 - Add extra documentation covering environment variables and running tests (#226) (5 weeks ago) <Richard Nias>
* 74dcbb6 - Removed typo errors and fixed contractions (#222) (2 months ago) <basifat>
* a4dfed6 - Allow prof_file to be blank, not null (#220) (2 months ago) <Richard Nias>
* 58d7781 - gprof2dot had a breaking change in 2017.09.19 (#221) (2 months ago) <Richard Nias>
* 6c53b4e - Changed the theme of gprof2dot output to be more inline with rest of silk design (#210) (4 months ago) <Daniel Bradburn>
* 688f409 - configurable storage class (#204) (5 months ago) <smcoll>
* bdf2cdb - increase Request.prof_file max_length to 300 (#203) (5 months ago) <smcoll>
* 9238da0 - left align pre tag (#199) (5 months ago) <smcoll>
* d27247b - #33 organise cprofile output as a sortable table (#200) (5 months ago) <danielbradburn>
* 69a2227 - Adds quotes to distributions setting (5 months ago) <Andrew Velis>
* fc67147 - add .venv* to .gitignore (#198) (5 months ago) <danielbradburn>
* 25075b3 - added missing gprof2dot to setup.py which is required for the graph visualization (#197) (5 months ago) <danielbradburn>
* 9b0d5a9 - added information about graph visualization and sql summary table sorting to README.md (#195) (5 months ago) <danielbradburn>
* 53b5ea7 - Adds deployment setting to TravisCI config (5 months ago) <Andrew Velis>
* a1504fd - Updates spaces in Travis CI config (5 months ago) <Andrew Velis>
* db257ea - added method filter to filter requests by http verb (#194) (5 months ago) <danielbradburn>
* 34b3caa - Visualize profile result (#192) (5 months ago) <danielbradburn>
* 0337591 - Sortable sql table (#193) (5 months ago) <danielbradburn>
*   23ecc35 - Merge pull request #191 from crunchr/status_code_filter (6 months ago) <Andrew Velis>
|\
| * 647fadd - Fixed accidental removal of [''] + in _get_paths function (6 months ago) <danielbradburn>
| * a83bde5 - added filter to filter the requests that are shown based on the status code of the response (6 months ago) <Daniel Bradburn>
|/
*   0572547 - Merge branch 'fix-tests' (6 months ago) <Albert Wang>
|\
| * 62849f0 - Skip flaky test (6 months ago) <Albert Wang>
| * 96d03b5 - Fix tests (6 months ago) <Albert Wang>
| * 5daa78e - Fix divide by zero (6 months ago) <Albert Wang>
|/
* e14992c - Fix tests (6 months ago) <Albert Wang>
*   7538ee0 - Merge branch 'request-limit' (6 months ago) <Albert Wang>
|\
| * 5b5b8e3 - Fixes for garbage collection (6 months ago) <Albert Wang>
|/
*   fe1ee33 - Merge pull request #188 from albertyw/on-delete (6 months ago) <Andrew Velis>
|\
| * f04d2b7 - Add on_delete to foreign key and one to one relationships (6 months ago) <Albert Wang>
* |   35684b3 - Merge pull request #189 from albertyw/test-python-3.6 (6 months ago) <Andrew Velis>
|\ \
| * | 9e59c8d - Add python 3.6 to travis config (6 months ago) <Albert Wang>
| |/
* |   2d2c35e - Merge pull request #190 from albertyw/request-limit (6 months ago) <Andrew Velis>
|\ \
| * | 662f5d1 - Move garbage collection from Response to Request and fix dependency cleanup (6 months ago) <Albert Wang>
| * | 2c514d4 - Call garbage collection on save (6 months ago) <Albert Wang>
| * | d82d6c0 - Add docs (6 months ago) <Albert Wang>
| * | 3052c27 - Add ability for silk to prune its database (6 months ago) <Albert Wang>
| |/
* |   9a17d6b - Merge pull request #186 from albertyw/jazzband (6 months ago) <Andrew Velis>
|\ \
| |/
|/|
| * 19edd67 - Remove rst readme (6 months ago) <Albert Wang>
| * 29e8448 - Replace django-silk organization with jazzband (6 months ago) <Albert Wang>
|/
* 24c6878 - Update README.md (6 months ago) <Michael Ford>
* b9ccbe7 - Update README.md (6 months ago) <Michael Ford>
*   89bdcff - Merge pull request #185 from django-silk/jazzband (6 months ago) <Andrew Velis>
|\
| * 2731a71 - Added a contributing section to README.md (6 months ago) <Michael Ford>
| * c5408db - Added Jazzband badge to README.md (6 months ago) <Michael Ford>
| * 66cfd63 - Added Jazzband CONTRIBUTING.md (6 months ago) <Michael Ford>
|/
* 27e49e7 - Adds spacing and help comment (6 months ago) <Andrew Velis>
* 01bacc2 - Adds import line for decorator example (6 months ago) <Andrew Velis>
* bd387af - Adds import line for silk profile decorator (6 months ago) <Andrew Velis>
* f8f4fe2 - Updates Django under requirements header (7 months ago) <Andrew Velis>
*   d6808c9 - Merge pull request #177 from lammertw/lammertw-patch-1 (7 months ago) <Andrew Velis>
|\
| * 5cf3b83 - Deprecation: update to warning (7 months ago) <Lammert Westerhoff>
|/
* 370d9f3 - Adds text-align property to pyprofile class for readability (#176) (8 months ago) <Jeffrey Chau>
* 2fdcaee - Updates Django 1.11 version in tox config (8 months ago) <Andrew Velis>
* 08ac514 - Mentions collectstatic (#173) (8 months ago) <Karl Goetz>
```